### PR TITLE
utvm_gen_graph_and_params.py: Fix Deprecation

### DIFF
--- a/examples/utvm_gen_graph_and_params.py
+++ b/examples/utvm_gen_graph_and_params.py
@@ -94,7 +94,9 @@ class TVMFlow:
             cfg = { "tir.disable_vectorize": True }
 
         with tvm.transform.PassContext(opt_level=self.opt_level, config=cfg):
-            self.graph, c_mod, self.c_params = relay.build(self.mod, self.target, params=self.params)
+            c_mod = relay.build(self.mod, target=self.target, params=self.params)
+            self.graph = c_mod.get_json()
+            self.c_params = c_mod.get_params()
 
         if not self.local:
             # Cross compile


### PR DESCRIPTION
This Warning should no longer be printed:

```
utvm_gen_graph_and_params.py:97: DeprecationWarning: legacy graph executor behavior of producing json / lib / params will be removed in the next release. Please see documents of tvm.contrib.graph_executor.GraphModule for the  new recommended usage.
```