### PR TITLE
Fix: Rename DLContext to DLDevice

### DIFF
--- a/examples/codegen.py
+++ b/examples/codegen.py
@@ -87,8 +87,8 @@ void *TVMWrap_GetInputPtr(int index)
 
     DLTensor input;
     input.data = (void*)data[index];
-    DLContext ctx = {kDLCPU, 0};
-    input.ctx = ctx;
+    DLDevice device = {kDLCPU, 0};
+    input.device = device;
     input.ndim = ${inNDims};
     input.dtype = dtypes[index];
     input.shape = shapes[index];
@@ -111,8 +111,8 @@ void *TVMWrap_GetOutputPtr(int index)
 
     DLTensor output;
     output.data = (void*)data[index];
-    DLContext ctx = {kDLCPU, 0};
-    output.ctx = ctx;
+    DLDevice device = {kDLCPU, 0};
+    output.device = device;
     output.ndim = ${outNDims};
     output.dtype = dtypes[index];
     output.shape = shapes[index];


### PR DESCRIPTION
See latest changes in TVM and dlpack:
- https://github.com/apache/tvm/pull/7721
- https://discuss.tvm.apache.org/t/rfc-rename-tvmcontext-to-tvmdevice/9090
- https://github.com/dmlc/dlpack/commit/8323706bb5b2298f3c432e5fc23d75c8f3058a51#diff-1564e5abd0da5cf46e82b28b0058996df944007494520a2b0a6b629880eaa097