### PR TITLE
WIP: Latest improvements

### DIFF
--- a/examples/codegen.py
+++ b/examples/codegen.py
@@ -70,6 +70,7 @@ def generateTargetCode(outFileName, graph, params, modelInfo):
 
 #include <stdint.h>
 #include "tvm/runtime/c_runtime_api.h"
+#include "tvm/runtime/crt/packed_func.h"
 #include "bundle.h"
 
 '''
@@ -80,6 +81,8 @@ def generateTargetCode(outFileName, graph, params, modelInfo):
         f.write("const uint64_t g_params_size = " + str(len(params)) + ";\n")
 
         mainCode = '''
+
+TVMModuleHandle TVMArgs_AsModuleHandle(const TVMArgs* args, size_t index);
 
 void *g_handle = NULL;
 

--- a/examples/run_flow.sh
+++ b/examples/run_flow.sh
@@ -17,5 +17,6 @@ run_test() {
     cd ../..
 }
 
-run_test sine_model.tflite 0
+run_test sine_model.tflite 64
+# Warning: Results for cifar10 will be worng because there is more than one Allocation per Operator!
 run_test cifar10.tflite 28800

--- a/examples/run_flow.sh
+++ b/examples/run_flow.sh
@@ -18,5 +18,5 @@ run_test() {
 }
 
 run_test sine_model.tflite 64
-# Warning: Results for cifar10 will be worng because there is more than one Allocation per Operator!
+# Warning: Results for cifar10 will be wrong because there is more than one Allocation per Operator!
 run_test cifar10.tflite 28800

--- a/examples/target_src/main.c
+++ b/examples/target_src/main.c
@@ -1,6 +1,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "tvm_wrapper.h"
 
 #ifdef _DEBUG
 #include <stdio.h>
@@ -8,12 +9,6 @@
 #else
 #define DBGPRINTF(format, ...)
 #endif
-
-
-void TVMWrap_Init();
-void *TVMWrap_GetInputPtr(int index);
-void TVMWrap_Run();
-void *TVMWrap_GetOutputPtr(int index);
 
 int main()
 {

--- a/examples/target_src/main.c
+++ b/examples/target_src/main.c
@@ -1,8 +1,6 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "tvm/runtime/c_runtime_api.h"
-
 
 #ifdef _DEBUG
 #include <stdio.h>
@@ -12,18 +10,10 @@
 #endif
 
 
-#include <tvm/runtime/crt/packed_func.h>
-TVMModuleHandle TVMArgs_AsModuleHandle(const TVMArgs* args, size_t index);
-
-
 void TVMWrap_Init();
 void *TVMWrap_GetInputPtr(int index);
 void TVMWrap_Run();
 void *TVMWrap_GetOutputPtr(int index);
-
-
-void TVMPlatformAbort(tvm_crt_error_t e) { exit(1); }
-
 
 int main()
 {

--- a/examples/target_src/tvm_wrapper.h
+++ b/examples/target_src/tvm_wrapper.h
@@ -1,0 +1,13 @@
+#ifndef TVM_WRAPPER_H
+#define TVM_WRAPPER_H
+
+#include <stddef.h>
+
+void TVMWrap_Init();
+void *TVMWrap_GetInputPtr(int index);
+size_t TVMWrap_GetInputSize(int index);
+void TVMWrap_Run();
+void *TVMWrap_GetOutputPtr(int index);
+size_t TVMWrap_GetOutputSize(int index);
+
+#endif  // TVM_WRAPPER_H

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -69,7 +69,9 @@ void CodeGenerator::generateCode(const std::string &outFileName, size_t workspac
             << "\n";
     }
 
+    out << "#include <stdlib.h>\n";
     out << "#include <string.h>\n";
+    out << "#include <tvm/runtime/crt/error_codes.h>\n";
     out << "#include \"tvm/runtime/c_runtime_api.h\"\n\n";
     out << "typedef struct ArgInfo { void *buffer; size_t size; } ArgInfo;\n\n";
 
@@ -174,5 +176,9 @@ void *TVMWrap_GetOutputPtr(int index);
 size_t TVMWrap_GetOutputSize(int index);
 
 #endif
+void TVMPlatformAbort(tvm_crt_error_t code) {
+  exit(1);
+}
 )CODE";
+
 }

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -158,24 +158,7 @@ void* TVMBackendAllocWorkspace(int device_type, int device_id, uint64_t nbytes, 
 int TVMBackendFreeWorkspace(int device_type, int device_id, void* ptr) {
   return 0;
 }
-)CODE";
 
-    std::ofstream outH(outFileName + ".h");
-    outH << R"CODE(
-#ifndef UTVM_STATICRT_CODEGEN_H
-#define UTVM_STATICRT_CODEGEN_H
-
-#include <stddef.h>
-
-
-void TVMWrap_Init();
-void *TVMWrap_GetInputPtr(int index);
-size_t TVMWrap_GetInputSize(int index);
-void TVMWrap_Run();
-void *TVMWrap_GetOutputPtr(int index);
-size_t TVMWrap_GetOutputSize(int index);
-
-#endif
 void TVMPlatformAbort(tvm_crt_error_t code) {
   exit(1);
 }


### PR DESCRIPTION
- Get rid of the need to call TVMArgs_AsModuleHandle and remove unnecessary source files when linking tvm_staticrt lib
- Increase number of required workspace bytes for example models
- Rename header file `staticrt.c.h` to more generic name `tvm_wrapper.h` and store it without generating it exclusively  using the compiler executable.