### PR TITLE
Add TVMWrap_GetNumInputs/Outputs() to wrappers

### DIFF
--- a/examples/codegen.py
+++ b/examples/codegen.py
@@ -117,6 +117,11 @@ size_t TVMWrap_GetInputSize(int index)
     return sizes[index];
 }
 
+size_t TVMWrap_GetNumInputs()
+{
+    return ${numInputs};
+}
+
 void TVMWrap_Run()
 {
     tvm_runtime_run(g_handle);
@@ -147,6 +152,11 @@ size_t TVMWrap_GetOutputSize(int index)
 
     return sizes[index];
 }
+
+size_t TVMWrap_GetNumOutputs()
+{
+    return ${numOutputs};
+}
 '''
         f.write(fill(
             mainCode,
@@ -155,5 +165,7 @@ size_t TVMWrap_GetOutputSize(int index)
             inNDims=2,
             outNDims=2,
             inSizes=getSizes(modelInfo.inTensors),
-            outSizes=getSizes(modelInfo.outTensors)))
+            outSizes=getSizes(modelInfo.outTensors),
+            numInputs=len(modelInfo.inTensors),
+            numOutputs=len(modelInfo.outTensors)))
 

--- a/examples/target_src/tvm_wrapper.h
+++ b/examples/target_src/tvm_wrapper.h
@@ -6,8 +6,10 @@
 void TVMWrap_Init();
 void *TVMWrap_GetInputPtr(int index);
 size_t TVMWrap_GetInputSize(int index);
+size_t TVMWrap_GetNumInputs();
 void TVMWrap_Run();
 void *TVMWrap_GetOutputPtr(int index);
 size_t TVMWrap_GetOutputSize(int index);
+size_t TVMWrap_GetNumOutputs();
 
 #endif  // TVM_WRAPPER_H

--- a/src/CodeGen.cpp
+++ b/src/CodeGen.cpp
@@ -141,6 +141,10 @@ size_t TVMWrap_GetInputSize(int index)
 {
   return inArgInfo[index].size;
 }
+size_t TVMWrap_GetNumInputs()
+{
+  return )CODE" << m_inArgs.size() << R"CODE(;
+}
 void *TVMWrap_GetOutputPtr(int index)
 {
   return outArgInfo[index].buffer;
@@ -148,6 +152,10 @@ void *TVMWrap_GetOutputPtr(int index)
 size_t TVMWrap_GetOutputSize(int index)
 {
   return outArgInfo[index].size;
+}
+size_t TVMWrap_GetNumOutputs()
+{
+  return )CODE" << m_outArgs.size() << R"CODE(;
 }
 
 void* TVMBackendAllocWorkspace(int device_type, int device_id, uint64_t nbytes, int dtype_code_hint,


### PR DESCRIPTION
This is a prerequisite for the downstream changes to the MLIF lib.